### PR TITLE
Fix Interpolation Tables to work with OF8

### DIFF
--- a/src/rsr/interpolations/basicInterpolationTable/basicInterpolationTable.C
+++ b/src/rsr/interpolations/basicInterpolationTable/basicInterpolationTable.C
@@ -25,6 +25,7 @@ License
 
 #include "basicInterpolationTable.H"
 #include "fileName.H"
+#include "TableFile.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -157,7 +158,7 @@ Foam::basicInterpolationTable<Type>::basicInterpolationTable
 )
 :
     fileName_(dict.lookup("file")),
-    reader_(tableReader<List<Type>>::New(dict)),
+    reader_(TableReader<List<Type>>::New("foam", dict)),
     values_(),
 	isPeriodic_(dict.lookupOrDefault<bool>("periodic", false)),
 	startTime_(0),

--- a/src/rsr/interpolations/basicInterpolationTable/basicInterpolationTable.H
+++ b/src/rsr/interpolations/basicInterpolationTable/basicInterpolationTable.H
@@ -55,7 +55,7 @@ SourceFiles
 #include "List.H"
 #include "Tuple2.H"
 #include "dictionary.H"
-#include "tableReaders.H"
+#include "TableReader.H"
 #include "fieldTypes.H"
 #include "autoPtr.H"
 #include "runTimeSelectionTables.H"
@@ -80,7 +80,7 @@ protected:
         fileName fileName_;
 
         //- Values reader
-        autoPtr<tableReader<List<Type>>> reader_;
+        autoPtr<TableReader<List<Type>>> reader_;
 
         //- Values as a List
         List<Tuple2<scalar, List<Type>>> values_;

--- a/src/rsr/interpolations/basicInterpolationTable/basicInterpolationTables.C
+++ b/src/rsr/interpolations/basicInterpolationTable/basicInterpolationTables.C
@@ -30,8 +30,8 @@ License
 #include "tensorList.H"
 
 #include "basicInterpolationTables.H"
-#include "tableReaders.H"
-#include "openFoamTableReader.H"
+#include "TableReader.H"
+//#include "openFoamTableReader.H"
 #include "addToRunTimeSelectionTable.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -42,8 +42,8 @@ namespace Foam
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
 #define defineTableReaderType(dataType)                                        \
-    defineNamedTemplateTypeNameAndDebug(tableReader<dataType >, 0);            \
-    defineTemplatedRunTimeSelectionTable(tableReader, dictionary, dataType);
+    defineNamedTemplateTypeNameAndDebug(TableReader<dataType >, 0);            \
+    defineTemplatedRunTimeSelectionTable(TableReader, dictionary, dataType);
 
 #define makeListTableReaders(typeTableReader)                                  \
                                                                                \
@@ -62,14 +62,24 @@ namespace Foam
     );
 
 // Define Base Table Readers for list types
-defineTableReaderType(scalarList);
-defineTableReaderType(vectorList);
-defineTableReaderType(sphericalTensorList);
-defineTableReaderType(symmTensorList);
-defineTableReaderType(tensorList);
+#define makeTableReaders(Type)                                                 \
+    defineTableReader(Type);                                                   \
+    makeTableReader(Foam, Type)
+
+makeTableReaders(scalarList);
+makeTableReaders(vectorList);
+makeTableReaders(sphericalTensorList);
+makeTableReaders(symmTensorList);
+makeTableReaders(tensorList);
+
+//defineTableReaderType(scalarList);
+//defineTableReaderType(vectorList);
+//defineTableReaderType(sphericalTensorList);
+//defineTableReaderType(symmTensorList);
+//defineTableReaderType(tensorList);
 
 // Declare OpenFOAM readers for list tables
-makeListTableReaders(openFoamTableReader);
+//makeListTableReaders(openFoamTableReader);
 
 // Define Base Interpolation Tables for primitive types
 defineInterpolationTableType(scalar);

--- a/src/rsr/interpolations/linearInterpolationTable/linearInterpolationTable.H
+++ b/src/rsr/interpolations/linearInterpolationTable/linearInterpolationTable.H
@@ -36,7 +36,7 @@ SourceFiles
 #define linearInterpolationTable_H
 
 #include "basicInterpolationTable.H"
-#include "tableReader.H"
+#include "TableReader.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/rsr/interpolations/steppedInterpolationTable/steppedInterpolationTable.H
+++ b/src/rsr/interpolations/steppedInterpolationTable/steppedInterpolationTable.H
@@ -36,7 +36,7 @@ SourceFiles
 #define steppedInterpolationTable_H
 
 #include "basicInterpolationTable.H"
-#include "tableReader.H"
+#include "TableReader.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 


### PR DESCRIPTION
Incorporates new OF8 Foam TableReader into `basicInterpolationTable`